### PR TITLE
Fix route prefix

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -21,9 +21,8 @@ server.register({
 });
 
 // Register HTTP endpoints
-server.register({
-  register: require('../plugins/endpoints'),
-  options: { route: { prefix: '/api' } }
+server.register({register: require('../plugins/endpoints')}, {
+  routes: { prefix: '/api' }
 }, function (/* err */) {
 
 });

--- a/test/example.js
+++ b/test/example.js
@@ -36,7 +36,7 @@ lab.experiment('endpoints', function () {
   lab.test('resolves example request', function (done) {
     server.inject({
       method: 'POST',
-      url: '/example',
+      url: '/api/example',
       headers: {
         'Content-Type': 'application/json'
       },


### PR DESCRIPTION
Prefix now applies - I think the code would have worked for a slightly older version of hapi
